### PR TITLE
chore: clarify worker client example code

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,4 +1,8 @@
-// Worker
+/*
+Worker (client) implementation. Durable Objects are only accessible from
+Cloudflare Workers, including other Durable Objects. In this (commented)
+example, a Cloudflare Worker calls the fetch method of the Durable Object
+implemented below.
 
 export default {
   async fetch(request, env) {
@@ -14,6 +18,7 @@ async function handleRequest(request, env) {
 
   return new Response("Durable Object 'A' count: " + count);
 }
+ */
 
 // Durable Object
 


### PR DESCRIPTION
This change helps me understand that the example Worker client should not actually live here in the DO. Instead, it is an example that one could copy-paste to their Worker, in order to use the DO.

IMPORTANT: This breaks `wrangler publish`. I suggest that the maintainers use this PR to reproduce this before merging: Durable Objects must export a namespace-level `fetch()` method, but the method is never called.

```console
% npx wrangler publish
✨  No build command specified, skipping build.
Error: Something went wrong with the request to Cloudflare...
The uploaded script has no registered event handlers. [API code: 10068]
```